### PR TITLE
Add test messenger QR to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 *.ipr
 *.iws
 .idea/
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -197,3 +197,6 @@ Summary
 > Final cost:          0.118115450004724618 ETH
 ```
 
+## Access via LINE
+The LINE Messenger API allows us to receive URLs via LINE.
+![image](https://github.com/Finschia/flutter-bird/assets/55307968/b4f6ac13-f167-4090-b4c2-0e4294845608)


### PR DESCRIPTION
## Description
close #6 

Since we are trying out flutter as a LIFF App on LINE, I added a messenger QR code that gives us the LIFF App link to the readme.