### PR TITLE
Set QR to correct position

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,5 @@ Summary
 
 ## Access via LINE
 The LINE Messenger API allows us to receive URLs via LINE.
+
 ![image](https://github.com/Finschia/flutter-bird/assets/55307968/b4f6ac13-f167-4090-b4c2-0e4294845608)


### PR DESCRIPTION
## Description
The QR code is currently placed at the end of the sentence, so we will correct its location.


As is
<img width="928" alt="スクリーンショット 2024-07-10 11 14 50" src="https://github.com/Finschia/flutter-bird/assets/55307968/7533a65d-abb6-4a8c-b614-b0433f998f8c">

To be
<img width="951" alt="スクリーンショット 2024-07-10 11 17 12" src="https://github.com/Finschia/flutter-bird/assets/55307968/bce2014f-e4da-4fbe-88cf-b4a9dc0ee8bc">